### PR TITLE
feat: Copy code to clipboard button

### DIFF
--- a/src/components/header/ButtonShowCode.tsx
+++ b/src/components/header/ButtonShowCode.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { useThemeContext } from "@/src/contexts/ThemeContext/ThemeContext";
 import { Button } from "@/src/components/shadcn/button";
 import {
@@ -16,6 +19,7 @@ import {
 } from "@/src/components/shadcn/tabs";
 import { generateShadcnCssVariables } from "@/src/utils/generateShadcnCssVariables";
 import SyntaxHighlighter from "react-syntax-highlighter/dist/esm/default-highlight";
+import CopyButton from "./CopyCodeButton";
 
 export default function ButtonShowCode() {
   const {
@@ -23,8 +27,15 @@ export default function ButtonShowCode() {
       shadcn: { dark, light },
     },
   } = useThemeContext();
+  const [activeTab, setActiveTab] = useState("light-code");
+
   const lightCssPalette = generateShadcnCssVariables(light);
   const darkCssPalette = generateShadcnCssVariables(dark);
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+  };
+
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -39,39 +50,49 @@ export default function ButtonShowCode() {
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Css Variables</DialogTitle>
+          <DialogTitle>CSS Variables</DialogTitle>
           <DialogDescription>
             You can use the following code to start integrating your application
             theme
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
-          <Tabs defaultValue="light-code">
-            <TabsList>
-              <TabsTrigger
-                onClick={() => {
-                  (window as any).gtag("event", "show-css-code-light");
-                }}
-                value="light-code"
-              >
-                Light
-              </TabsTrigger>
-              <TabsTrigger
-                onClick={() => {
-                  (window as any).gtag("event", "show-css-code-dark");
-                }}
-                value="dark-code"
-              >
-                Dark
-              </TabsTrigger>
-            </TabsList>
+          <Tabs defaultValue="light-code" onValueChange={handleTabChange}>
+            <header className="flex items-center justify-between">
+              <TabsList>
+                <TabsTrigger
+                  onClick={() => {
+                    (window as any).gtag("event", "show-css-code-light");
+                  }}
+                  value="light-code"
+                >
+                  Light
+                </TabsTrigger>
+                <TabsTrigger
+                  onClick={() => {
+                    (window as any).gtag("event", "show-css-code-dark");
+                  }}
+                  value="dark-code"
+                >
+                  Dark
+                </TabsTrigger>
+              </TabsList>
+
+              <div>
+                {/* SHOW CODE BUTTON BASED ON THE ACTIVE TAB */}
+                {activeTab === "dark-code" ? (
+                  <CopyButton codeToCopy={darkCssPalette} />
+                ) : (
+                  <CopyButton codeToCopy={lightCssPalette} />
+                )}
+              </div>
+            </header>
             <TabsContent value="light-code">
               <SyntaxHighlighter
                 style={{ "hljs-number": { color: "white" } }}
                 customStyle={{
                   background: "black",
                   color: "#c3c3c3",
-
                   height: "400px",
                   overflowY: "auto",
                   fontSize: "0.875rem",
@@ -89,12 +110,12 @@ export default function ButtonShowCode() {
                 customStyle={{
                   background: "black",
                   color: "#c3c3c3",
-
                   height: "400px",
                   overflowY: "auto",
                   fontSize: "0.875rem",
                   paddingInline: "12px",
                   borderRadius: "8px",
+                  position: "relative",
                 }}
                 language="css"
               >

--- a/src/components/header/CopyCodeButton.tsx
+++ b/src/components/header/CopyCodeButton.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+
+import { ClipboardIcon } from "lucide-react";
+import {
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipContent,
+  Tooltip,
+} from "../shadcn/tooltip";
+import { Button } from "../shadcn/button";
+
+interface CopyButtonProps {
+  codeToCopy: string;
+}
+
+export default function CopyButton({ codeToCopy }: CopyButtonProps) {
+  const handleCopy = () => {
+    navigator.clipboard.writeText(codeToCopy).then(
+      () => {
+        console.log("Text copied to clipboard");
+      },
+      (err) => {
+        console.error("Failed to copy text: ", err);
+      },
+    );
+  };
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Button variant="ghost" onClick={handleCopy}>
+            Copy to Clipboard <ClipboardIcon className="ml-2 h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Click to copy</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
I made 2 modifications:

**New component CopyCodeButton.tsx:** 
I created a reusable component that allows text to be copied to the clipboard. It uses the Clipboard API and provides a user interface with a tooltip to confirm the action to the user. 
This component can be extended for future functionality where copying text is required.

**Updated ButtonShowCode.tsx:** 
I modified this component to include the copy code button. Now, depending on the active tab (Light or Dark), the user can copy the corresponding CSS code with a single click.

![Screenshot 2024-08-19 124924](https://github.com/user-attachments/assets/221cb177-ee57-4cfd-8db3-4ea68102fbcd)
